### PR TITLE
Fix non-breaking spaces in titles

### DIFF
--- a/content/HowItWorks/DataModel.md
+++ b/content/HowItWorks/DataModel.md
@@ -31,7 +31,7 @@ Within an Endpoint a Node has one or more Clusters. These are another step in th
 
 A Node may also have several Endpoints, each creating an instance of the same functionality. For example, a light fixture may expose independent control of individual lights or a power strip may expose control of individual sockets.
 
-### Attributes
+### Attributes
 At the last level we'll find Attributes, which are states held by the node, such as the current level attribute of a level control cluster. Attributes may be defined as different data types such as uint8, strings or arrays.
 
 ![Nodes, Endpoints, Attributes and Commands](../..//primer-node-endpoint-attribute.png)
@@ -39,7 +39,7 @@ At the last level we'll find Attributes, which are states held by the node, such
 ### Commands
 Besides Attributes, Clusters also have Commands, which are actions that may be performed. They are the equivalent in Matter's data model of a remote procedure call. Commands are verb-like, such as lock door on a Door Lock cluster. Commands may generate responses and results; in Matter, such responses are also defined as Commands, going in the reverse direction.
 
-### Events
+### Events
 Lastly, Clusters may also have Events, which can be thought of as a record of past state transitions. While Attributes represent the current states, events are a journal of the past, and include a monotonically increasing counter, a timestamp and a priority. They enable capturing state transitions, as well as data modeling that is not readily achieved with attributes.
 
 ![A sample of the hierarchy of Matter Devices interaction model](../../primer-device-type.png)

--- a/content/HowItWorks/InteractionModel.md
+++ b/content/HowItWorks/InteractionModel.md
@@ -41,7 +41,7 @@ A Path in Matter can be assembled using one of the options below:
 
 And within these Path building blocks, `endpoint` and `cluster` may also include Wildcards Operators for selecting more than one Node instance.
 
-### Timed and Untimed
+### Timed and Untimed
 
 There are two ways of performing a Write or Invoke Transaction: Timed and Untimed. Timed Transactions establish a maximum timeout for the Write/Invoke Action to be sent. The purpose of this timeout is to prevent an Intercept Attack on the Transaction. It is especially valid for Devices that gate access to assets, such as garage openers and locks.
 

--- a/content/HowItWorks/Security.md
+++ b/content/HowItWorks/Security.md
@@ -50,5 +50,5 @@ of information
 Data shared between Matter nodes is strictly for a defined purpose, namely, for the specific operations
 of devices as required by the Matter protocol
 
-### Privacy preserving mechanisms
+### Privacy preserving mechanisms
 Encryption to ensure that messages or identities of communicating parties are not in cleartext on the network


### PR DESCRIPTION
This should fix the rendering of the changed headings, such as the one shown below:

<img width="1417" alt="Screenshot of a sentence from the documentation where all of the text is rendered in the same font. The text shows three # symbols then the word 'Attributes' and then the sentence 'At the last level we’ll find Attributes, which are states held by the node, such as the current level attribute of a level control cluster. Attributes may be defined as different data types such as uint8, strings or arrays.'" src="https://github.com/project-chip/matter-handbook/assets/30210785/00cf7572-0d0e-4c1f-bad8-f472165ac3a5">
