### PR TITLE
correcting minor typo in SDK page

### DIFF
--- a/content/SDK/_index.md
+++ b/content/SDK/_index.md
@@ -46,4 +46,4 @@ The platform layer contains device specific delegate implementations for most of
 
 The SDK contains abstraction layers for Python, Java and Kotlin controllers.
 
-The SDK is publically avalible on [GitHub](https://github.com/project-chip/connectedhomeip)
+The SDK is publically available on [GitHub](https://github.com/project-chip/connectedhomeip)


### PR DESCRIPTION
correcting minor typo found in the SDK page