### PR TITLE
Add a gemini config file

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,9 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true


### PR DESCRIPTION
This matches the config in the SDK, and turns down the verbosity on the summaries, which SHOULD be self-explanatory given that this entire thing is documentation. 