### PR TITLE
Upgrading SDK and matter.js matter versions

### DIFF
--- a/content/Development/_index.md
+++ b/content/Development/_index.md
@@ -13,7 +13,7 @@ The following table provides a general overview of various use cases for the ava
 
 | Use Case                                                                  | Official SDK | JavaScript SDK |
 |---------------------------------------------------------------------------|--------------|----------------|
-| Compliant with Matter version                                             | 1.4          | 1.4            |
+| Compliant with Matter version                                             | 1.4.1        | 1.4.1          |
 | Participate in development of new Matter features                         | X            | –              |
 | Use for embedded platforms with strict memory and performance constraints | X            | –              |
 | Chipset-specific implementations (e.g. Wi-Fi/Thread)                      | X            | –              |


### PR DESCRIPTION
matter.js released it's version 0.14.0 today which is Matter 1.41 compatible

I assume we still say that SDK is "just" 1.4.1 when it is effectively "unpublished 1.4.2"?