### PR TITLE
Remove CSA acronym

### DIFF
--- a/src/certification/certifying-a-product/development.md
+++ b/src/certification/certifying-a-product/development.md
@@ -184,7 +184,7 @@ In particular:
 -   Bridge devices should understand the bridge certification program and how
     certification of the supported device types works.
 
-Product manufacturers should be aware that the CSA has a sunset policy in effect
+Product manufacturers should be aware that the Alliance has a sunset policy in effect
 for prior specification revisions. See the
 [Sunset Policy](https://groups.csa-iot.org/wg/members-all/document/39617) for more
 information.

--- a/src/certification/certifying-a-product/development.md
+++ b/src/certification/certifying-a-product/development.md
@@ -105,7 +105,7 @@ the details of the security procedures within the Alliance.
 
 The Certification Declaration (CD) is provided by the Connectivity Standards Alliance certification team after an attesting product is
 certified. It is tied to the Vendor ID and Product ID (or IDs) of the certified
-product, and is signed by Alliance key. The public key corresponding to the signing key is
+product, and is signed by the Alliance. The public key corresponding to the signing key is
 well known and distributed through the DCL.
 
 - [CD Signing Certs Root CA](https://on.dcl.csa-iot.org/dcl/pki/all-certificates?subjectKeyId=97:E4:69:D0:C5:04:14:C2:6F:C7:01:F7:7E:94:77:39:09:8D:F6:A5)

--- a/src/certification/certifying-a-product/development.md
+++ b/src/certification/certifying-a-product/development.md
@@ -5,14 +5,14 @@ order: 99
 ![](/static/certification/development.png)
 
 > [!NOTE]
-> Some links on this page are only accessible to CSA members.
+> Some links on this page are only accessible to Alliance members.
 
 The process of developing a Matter product is highly dependent on the device
 being developed, the platform being used, and the policies of the company doing the development. There
 is no single "best" way to integrate Matter into a product. This guide aims to
 address the common considerations for Matter product development.
 
-- Information on the Connectivity Standards Alliance (CSA) open source SDK is available at the
+- Information on the Connectivity Standards Alliance (Alliance) open source SDK is available at the
 [Matter SDK documentation site](https://project-chip.github.io/connectedhomeip-doc/index.html).
 
 - Integration of the SDK on specific platforms is covered by the
@@ -68,7 +68,7 @@ As a part of the attestation chain, each attesting product needs to be provision
     -   Signed by a PAA (whose certificate is found in the DCL)
 
 Attesting products can either opt to purchase DAC provisioning packages from a Matter PKI provider or use their
-own PAA by operating a Certification Authority (CA) that conforms to the CSA PKI
+own PAA by operating a Certification Authority (CA) that conforms to the Connectivity Standards Alliance PKI
 requirements. Both of these options have an impact on the operational and/or BOM
 costs of the product and should therefore be considered early in the process.
 More information about this important product decision can be found in
@@ -78,10 +78,10 @@ Operation of a CA is covered by the PKI certificate policies and attested by the
 CPS.
 
 -   [Matter PKI Certificate policy](https://groups.csa-iot.org/wg/matter-tsg/document/25032)
--   [CSA PKI CPS Template](https://groups.csa-iot.org/wg/matter-tsg/document/27111)
+-   [PKI CPS Template](https://groups.csa-iot.org/wg/matter-tsg/document/27111)
 -   [Certificate Policy Self-Attestation Compliance Form](https://groups.csa-iot.org/wg/matter-tsg/document/27269)
 
-A list of PKI providers can be found on the CSA site:
+A list of PKI providers can be found on the Alliance site:
 
 -   [Product Attestation Authorities](https://csa-iot.org/certification/paa/)
 
@@ -98,15 +98,15 @@ Test DACs are not permitted during certification testing, and devices must arriv
 with individually provisioned DACs in order to show that the device can meet the requirements
 around individual provisioning. Devices at certification are not required to use production DACs.
 
-Device manufacturers may wish to consider joining the CSA early in the process to understand
+Device manufacturers may wish to consider joining the Alliance early in the process to understand
 the details of the security procedures within the Alliance.
 
 ### Certification Declaration (CD)
 
-The Certification Declaration (CD) is provided by the CSA after an attesting product is
+The Certification Declaration (CD) is provided by the Connectivity Standards Alliance certification team after an attesting product is
 certified. It is tied to the Vendor ID and Product ID (or IDs) of the certified
-product, and is signed by CSA. The public key corresponding to the signing key is
-well known and distributed by the CSA through the DCL.
+product, and is signed by Alliance key. The public key corresponding to the signing key is
+well known and distributed through the DCL.
 
 - [CD Signing Certs Root CA](https://on.dcl.csa-iot.org/dcl/pki/all-certificates?subjectKeyId=97:E4:69:D0:C5:04:14:C2:6F:C7:01:F7:7E:94:77:39:09:8D:F6:A5)
 

--- a/src/certification/certifying-a-product/membership.md
+++ b/src/certification/certifying-a-product/membership.md
@@ -4,7 +4,7 @@ order: 100
 ---
 ![](/static/certification/membership.png)
 
-Companies need to be a member of the Connectivity Standards Alliance (CSA) in order to certify and release
+Companies need to be a member of the Connectivity Standards Alliance (Alliance) in order to certify and release
 products using Matter.
 
 See [Becoming a Member](https://csa-iot.org/become-member/) to learn more about

--- a/src/certification/certifying-a-product/membership.md
+++ b/src/certification/certifying-a-product/membership.md
@@ -8,10 +8,10 @@ Companies need to be a member of the Connectivity Standards Alliance (Alliance) 
 products using Matter.
 
 See [Becoming a Member](https://csa-iot.org/become-member/) to learn more about
-joining the CSA.
+joining the Alliance.
 
 A Vendor ID is used to identify the manufacturer of products and is required before
-certifying a product. Vendor IDs are assigned by the CSA and appear in the device
+certifying a product. Vendor IDs are assigned by the Alliance and appear in the device
 firmware and in the attestation certificates to identify the manufacturer and show the
 product has been properly certified. Companies should send requests for new Vendor
 IDs to [help@csa-iot.org](mailto:help@csa-iot.org) or through the

--- a/src/certification/certifying-a-product/self-pre-test.md
+++ b/src/certification/certifying-a-product/self-pre-test.md
@@ -5,7 +5,7 @@ order: 98
 ![](/static/certification/self-pre-test.png)
 
 > [!NOTE]
-> Some links on this page are only accessible to CSA members.
+> Some links on this page are only accessible to Alliance members.
 
 Before submitting a product for formal certification testing, doing a self pre-test is
 important to identify and fix certification-blocking bugs.
@@ -71,12 +71,12 @@ is available in the [Matter release folder](https://groups.csa-iot.org/wg/member
 Documentation around common problems when running tests can be found in the
 [`matter-test-scripts` repository](https://github.com/project-chip/matter-test-scripts/tree/main/docs/common_test_failures).
 
-The CSA has a dedicated Slack channel for test harness questions at (#csg-matter-test-harness-help).
+The Matter test harness tiger team has a dedicated Slack channel for test harness questions at (#csg-matter-test-harness-help).
 
 Questions about tests for specific clusters can also be directed to the supporting Tiger Team.
 
 In the case where a test case bug is identified, the affected manufacturer should file a request with
 the Change Control Board (CCB). Information about the CCB process can be found in the
-[CSA policies and procedures](https://groups.csa-iot.org/wg/members/document/21624), chapter 11.
+[Alliance policies and procedures](https://groups.csa-iot.org/wg/members/document/21624), chapter 11.
 
 CCB requests are filed in the [CCB tool](https://zigbeecertifiedproducts.knack.com/zigbee-alliance-ccb-tool).

--- a/src/certification/guides/pics-and-pixit.md
+++ b/src/certification/guides/pics-and-pixit.md
@@ -4,9 +4,8 @@ order: 100
 ---
 ## PICS
 
-In many Standards Defining Organizations including the CSA, the concept of a
-“Protocol Implementation Conformance Statement” or “PICS” code is introduced to
-simplify description of protocol elements.
+In many Standards Defining Organizations including the Connectivity Standards Alliance,
+the concept of a “Protocol Implementation Conformance Statement” or “PICS” code is introduced to simplify description of protocol elements.
 
 Each PICS code is a binary value that describes the presence or absence of a
 particular element or capability on a device. Each cluster has a defined PICS
@@ -41,7 +40,7 @@ the following PICS codes would be defined
 | ANC.C.E00     | Device ANC client understands the event with id 0x00                       |
 
 More information about the PICS code format can be found at
-[PICS Guidelines](https://github.com/CHIP-Specifications/chip-test-plans/blob/master/docs/PICS%20Guidelines.md). (requires access to the CSA specifications repo)
+[PICS Guidelines](https://github.com/CHIP-Specifications/chip-test-plans/blob/master/docs/PICS%20Guidelines.md). (requires access to the Matter specifications repo)
 
 In addition to these standard cluster PICS, other PICS may be defined to
 describe capabilities that are not directly expressed via the data model. For
@@ -66,7 +65,7 @@ to manually set all the PICS codes for a device. The PICS XML files and the PICS
 tool are distributed as part of the official specification release package and
 are available to members on
 [Causeway](https://groups.csa-iot.org/wg/members-all/document/folder/2269)
-(requires CSA member login).
+(requires Alliance member login).
 
 ## PIXITs
 
@@ -104,7 +103,7 @@ every endpoint.
 
 ### Helper scripts
 
-The official tooling for CSA certification is the PICS tool provided as a part
+The official tooling for Matter certification is the PICS tool provided as a part
 of the release. PICS files need to pass validation on the PICS tool to be valid
 for certification.
 
@@ -163,7 +162,7 @@ configuration.
 
 ## PICS for test selection
 
-The official source that the CSA certification team uses to determine if all the
+The official source that the Alliance certification team uses to determine if all the
 required tests have been run at certification is the submitted set of PICS XML
 files and the PICS tool.
 

--- a/src/glossary/index.md
+++ b/src/glossary/index.md
@@ -11,7 +11,7 @@ order: 100
 | ACL      | Access Control List. This is a list of entries in the Access Control cluster that grant access privileges to device and groups                                            |
 | adoc     | The filename suffix for asciidoc, which is the markup language we use to write the specification and test plans. [asciidoc](https://asciidoc.org/)                        |
 | Alchemy  | Alchemy is a command line tool for modifying and transforming Matter spec documents. [Alchemy](https://github.com/project-chip/alchemy) |
-| Alliance | Refers to the Connectivity Standards Alliance (CSA)                                                                                                                       |
+| Alliance | Refers to the Connectivity Standards Alliance                                                                                                                       |
 | AoE      | Anywhere on Earth. This acronym is commonly used when discussing deadlines to clarify the exact end time.|
 | asciidoc | Markup language we use to write the specification and test plans. [asciidoc](https://asciidoc.org/)                                                                       |
 | ATL      | Authorized Test Laboratory. ATLs run the tests required to certify devices. |
@@ -49,4 +49,4 @@ order: 100
 | TSG      | Technical Sub Group [TSG](https://groups.csa-iot.org/wg/matter-tsg/workgroup)                                                                                              |
 | TT       | Tiger team - a small group focused on one activity or feature.                                                                                                            |
 | VID      | Vendor identifier                                                                                                                                                         |
-| WG       | Work Group. [Matter](https://groups.csa-iot.org/wg/matter-wg/workgroup) is a working group in the CSA.                                                                 |
+| WG       | Work Group. [Matter](https://groups.csa-iot.org/wg/matter-wg/workgroup) is a working group in the Alliance.                                                                 |

--- a/src/specification/index.md
+++ b/src/specification/index.md
@@ -18,6 +18,6 @@ The specification is made up of a number of documents:
 
 All these documents can be downloaded from [The Alliance website](https://csa-iot.org/developer-resource/specifications-download-request/).
 
-For members, in-progress versions of the specification can be found in the [Secure document access portal](https://docs.csa-iot.org/) (requires CSA member login).
+For members, in-progress versions of the specification can be found in the [Secure document access portal](https://docs.csa-iot.org/) (requires Alliance member login).
 
 Members that are working on an approved feature and actively contributing to specification development may submit and review content in the [Specification GitHub Repository](https://github.com/CHIP-Specifications/connectedhomeip-spec). If you are a Participant or Promoter member and require access to the Specification GitHub Repository as a contributor, please email help@csa-iot.org.


### PR DESCRIPTION
Open question - what do you want to do with the CSA entry in the glossary. Still feels like possibly important info.