### PR TITLE
Add Matter Color Themes

### DIFF
--- a/retype.yml
+++ b/retype.yml
@@ -39,45 +39,69 @@ search:                              # Custom configuration of the website searc
 # -----------------------------------------------------------------------------
 theme:
   base:
-    base-bg: "#f3ffff"
-    base-color: "#29ab92"
-    base-text: "#131926"
-    base-text-muted: "#848c96"
-    base-text-strong: "#131926"
-    base-border: "#c8d1d9"
-    base-border-hover: "#848c96"
-    base-border-strong: "#848c96"
-    base-link: "#29ab92"
-    base-link-hover: "#218f7a"
-    base-item-text: "#131926"
-    base-item-text-active: "#218f7a"
-    base-item-bg-hover: "#e6f6f3"
-    base-item-bg-active: "#ccece5"
-    callout-base-bg: "#e6f6f3"
-    primary: "#29ab92"
-    badge-primary: "#e6f6f3"
-    badge-primary-border: "#ccece5"
-    callout-base-border: "#ccece5"
+    # Define common base colors as anchors with leading underscores 
+    # to indicate these keys are not meant to be parsed by the application.
+    _base-color-value: &base-color "#29ab92"
+    _base-text-value: &base-text "#131926"
+    _base-muted-value: &base-muted "#848c96"
+    _base-bg-value: &base-bg "#f3ffff"
+    _base-border-value: &base-border "#c8d1d9"
+    _base-link-hover-value: &base-link-hover "#218f7a"
+    _base-item-bg-hover-value: &base-item-bg-hover "#e6f6f3"
+    _base-item-bg-active-value: &base-item-bg-active "#ccece5"
+
+    # Use aliases for repeated values 
+    base-bg: *base-bg
+    base-color: *base-color
+    base-text: *base-text
+    base-text-muted: *base-muted
+    base-text-strong: *base-text
+    base-border: *base-border
+    base-border-hover: *base-muted
+    base-border-strong: *base-muted
+    base-link: *base-color
+    base-link-hover: *base-link-hover
+    base-item-text: *base-text
+    base-item-text-active: *base-link-hover
+    base-item-bg-hover: *base-item-bg-hover
+    base-item-bg-active: *base-item-bg-active
+    callout-base-bg: *base-item-bg-hover
+    primary: *base-color
+    badge-primary: *base-item-bg-hover
+    badge-primary-border: *base-item-bg-active
+    callout-base-border: *base-item-bg-active
   dark:
-    base-bg: "#131926"
-    base-color: "#50e3c2"
-    base-text: "#c8d1d9"
-    base-text-muted: "#848c96"
-    base-text-strong: "#f3ffff"
-    base-border: "#2a3442"
-    base-border-hover: "#c8d1d9"
-    base-border-strong: "#f3ffff"
-    base-link: "#50e3c2"
-    base-link-hover: "#94e9d7"
-    base-item-text: "#f3ffff"
-    base-item-text-active: "#94e9d7"
-    base-item-bg-hover: "#2a3442"
-    base-item-bg-active: "#3c4a5c"
-    callout-base-bg: "#2a3442"
-    primary: "#50e3c2"
-    badge-primary: "#2a3442"
-    badge-primary-border: "#3c4a5c"
-    callout-base-border: "#3c4a5c"
+    # Define common dark colors as anchors with leading underscores
+    # to indicate these keys are not meant to be parsed by the application.
+    _dark-color-value: &dark-color "#50e3c2"
+    _dark-text-value: &dark-text "#c8d1d9"
+    _dark-muted-value: &dark-muted "#848c96"
+    _dark-bg-value: &dark-bg "#131926"
+    _dark-border-value: &dark-border "#2a3442"
+    _dark-link-hover-value: &dark-link-hover "#94e9d7"
+    _dark-item-bg-hover-value: &dark-item-bg-hover "#2a3442"
+    _dark-item-bg-active-value: &dark-item-bg-active "#3c4a5c"
+
+    # Use aliases for repeated values
+    base-bg: *dark-bg
+    base-color: *dark-color
+    base-text: *dark-text
+    base-text-muted: *dark-muted
+    base-text-strong: &dark-strong-text "#f3ffff" # This value is unique and anchored for itself
+    base-border: *dark-border
+    base-border-hover: *dark-text
+    base-border-strong: *dark-strong-text
+    base-link: *dark-color
+    base-link-hover: *dark-link-hover
+    base-item-text: *dark-strong-text
+    base-item-text-active: *dark-link-hover
+    base-item-bg-hover: *dark-item-bg-hover
+    base-item-bg-active: *dark-item-bg-active
+    callout-base-bg: *dark-item-bg-hover
+    primary: *dark-color
+    badge-primary: *dark-item-bg-hover
+    badge-primary-border: *dark-item-bg-active
+    callout-base-border: *dark-item-bg-active
 
 # -----------------------------------------------------------------------------
 footer:

--- a/retype.yml
+++ b/retype.yml
@@ -37,5 +37,48 @@ search:                              # Custom configuration of the website searc
   noResultsFoundMsg: "No results found" # Message when no results are found
 
 # -----------------------------------------------------------------------------
+theme:
+  base:
+    base-bg: "#f3ffff"
+    base-color: "#29ab92"
+    base-text: "#131926"
+    base-text-muted: "#848c96"
+    base-text-strong: "#131926"
+    base-border: "#c8d1d9"
+    base-border-hover: "#848c96"
+    base-border-strong: "#848c96"
+    base-link: "#29ab92"
+    base-link-hover: "#218f7a"
+    base-item-text: "#131926"
+    base-item-text-active: "#218f7a"
+    base-item-bg-hover: "#e6f6f3"
+    base-item-bg-active: "#ccece5"
+    callout-base-bg: "#e6f6f3"
+    primary: "#29ab92"
+    badge-primary: "#e6f6f3"
+    badge-primary-border: "#ccece5"
+    callout-base-border: "#ccece5"
+  dark:
+    base-bg: "#131926"
+    base-color: "#50e3c2"
+    base-text: "#c8d1d9"
+    base-text-muted: "#848c96"
+    base-text-strong: "#f3ffff"
+    base-border: "#2a3442"
+    base-border-hover: "#c8d1d9"
+    base-border-strong: "#f3ffff"
+    base-link: "#50e3c2"
+    base-link-hover: "#94e9d7"
+    base-item-text: "#f3ffff"
+    base-item-text-active: "#94e9d7"
+    base-item-bg-hover: "#2a3442"
+    base-item-bg-active: "#3c4a5c"
+    callout-base-bg: "#2a3442"
+    primary: "#50e3c2"
+    badge-primary: "#2a3442"
+    badge-primary-border: "#3c4a5c"
+    callout-base-border: "#3c4a5c"
+
+# -----------------------------------------------------------------------------
 footer:
   copyright: "&copy; Copyright {{ year }} Matter Handbook Authors. <br>Matter is a registered trademark of the Connectivity Standards Alliance.<br>All other trademarks are property of their respective owners."


### PR DESCRIPTION
This pull request adds a new theme configuration to the `retype.yml` file, introducing both light and dark mode color schemes for the website.

### Theme configuration changes:

* [`retype.yml`](diffhunk://#diff-51e3f34ae21758348d19efce1c16d17b146daf28e7a9da5ba2950677185717eeR39-R81): Added a new `theme` section with detailed color settings for both light (`base`) and dark (`dark`) modes. This includes specifications for background colors, text colors, borders, links, and other UI elements to enhance the website's visual design to be more on-brand.

### Preview
<img width="3226" height="1760" alt="CleanShot 2025-07-16 at 17 17 08@2x" src="https://github.com/user-attachments/assets/25056417-c519-48e8-a3ed-92cfbf629418" />
<img width="3222" height="1764" alt="CleanShot 2025-07-16 at 17 17 18@2x" src="https://github.com/user-attachments/assets/7aefcc14-fa7c-4201-b02b-bc398474e35c" />
