### PR TITLE
Split Build and Deploy Workflows

### DIFF
--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -1,8 +1,6 @@
-name: PR preview - Publish    # PR Preview using Retype
+name: PR preview - Publish # PR Preview using Retype
 
 on:
-  # Trigger on pull request target events (opened, reopened, synchronized) or manual workflow dispatch.
-  # Use 'pull_request_target' so secrets are available for preview builds.
   pull_request_target:
     types:
       - opened
@@ -10,56 +8,33 @@ on:
       - synchronize
   workflow_dispatch:
 
-# Limit concurrency to one preview build per pull request. 
-# Cancel any in-progress preview build when a new commit is pushed to the same PR.
 concurrency: preview-${{ github.ref }}
 
-# Grant necessary permissions for writing content and PR comments.
 permissions:
   contents: write
   pull-requests: write
 
-# Set default shell to bash.
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  build-preview:
-    # Run build on Ubuntu.
-    runs-on: ubuntu-latest
+  build:
+    name: Build
+    uses: ./.github/workflows/retype-build.yml
+    with:
+      url: ${{ vars.PREVIEW_URL }}
+    secrets:
+      retype_license: ${{ secrets.RETYPE_LICENSE_PR_PREVIEW }}
+
+  deploy:
+    name: Deploy preview
+    needs: build
+    runs-on: ubuntu-22.04
     steps:
-      # Setup Node.js for npm, required for Retype installation.
-      - name: Install Node.js
-        uses: actions/setup-node@v5
+      - name: Download built artifact
+        uses: actions/download-artifact@v4
         with:
-          node-version: '20'
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: .retype # Fixed Retype output directory
 
-      # Install Retype CLI globally using npm for building the site.
-      - name: Install Retype CLI
-        run: |
-          npm install retypeapp --global
-          retype --version
-
-      # Fetch PR code for building the preview.
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          submodules: recursive
-
-      # Replace URL in retype.yml before building
-      - name: Replace URL in retype.yml
-        run: |
-          sed -i "s|url: https://handbook.buildwithmatter.com|url: ${{ vars.PREVIEW_URL }}|" retype.yml
-
-      # Generate the static site from the PR content using Retype.
-      - name: Build with Retype
-        run: |
-          retype build --key ${{ secrets.RETYPE_LICENSE_PR_PREVIEW }}
-
-      # Upload the generated site to S3 for preview hosting.
-      - name: Deploy preview
+      - name: Deploy to S3
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --acl public-read --follow-symlinks --delete
@@ -67,10 +42,9 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: './.retype'
-          DEST_DIR: 'pr-${{ github.event.number }}'
+          SOURCE_DIR: ./.retype # Matches fixed Retype output directory
+          DEST_DIR: pr-${{ github.event.number }}
 
-      # Clear CloudFront cache for the updated preview.
       - name: Invalidate CloudFront
         uses: chetan/invalidate-cloudfront-action@v2
         env:
@@ -80,10 +54,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      # Post the preview URL as a comment on the pull request.
-      - name: Comment PR
+      - name: Comment PR with preview URL
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
             Preview deployed at ${{ vars.PREVIEW_URL }}/pr-${{ github.event.number }}
-            

--- a/.github/workflows/pr-preview-remove.yml
+++ b/.github/workflows/pr-preview-remove.yml
@@ -1,4 +1,4 @@
-name: PR preview - Remove  # When PR is closed
+name: PR preview - Remove # When PR is closed
 
 on:
   # Trigger when a pull request target is closed.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,38 @@
 name: Publish to GitHub Pages
 
 on:
-  # Trigger on push to main branch
   push:
     branches:
       - main
-  # Manual trigger
   workflow_dispatch:
 
 jobs:
-  publish:
-    name: Publish to retype branch
+  build:
+    name: Build Retype Site
+    uses: ./.github/workflows/retype-build.yml
+    with:
+      url: ${{ vars.SITE_URL }}
+    secrets:
+      retype_license: ${{ secrets.RETYPE_LICENSE }}
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
     runs-on: ubuntu-22.04
     steps:
-      # Checkout repo
-      - uses: actions/checkout@v5
+      - name: Checkout (for gh-pages history)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-      # Build site using Retype. Include License
-      - uses: retypeapp/action-build@latest
-        env:
-          RETYPE_KEY: ${{ secrets.RETYPE_LICENSE }}
+      - name: Download built artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          # Fixed Retype output directory
+          path: .retype
 
-      # Deploy to GitHub Pages
-      - uses: retypeapp/action-github-pages@latest
+      - name: Publish
+        uses: retypeapp/action-github-pages@latest
         with:
           update-branch: true

--- a/.github/workflows/retype-build.yml
+++ b/.github/workflows/retype-build.yml
@@ -1,0 +1,54 @@
+name: Retype Build
+
+on:
+  workflow_call:
+    inputs:
+      url:
+        description: 'Base URL to inject via Retype override'
+        required: true
+        type: string
+    secrets:
+      retype_license:
+        required: true
+    outputs:
+      artifact_name:
+        description: 'Name of the uploaded artifact'
+        value: ${{ jobs.build.outputs.artifact_name }}
+      site_dir:
+        description: 'Directory containing the built site'
+        value: ${{ jobs.build.outputs.site_dir }}
+
+jobs:
+  build:
+    name: Build Retype
+    runs-on: ubuntu-22.04
+    outputs:
+      artifact_name: ${{ steps.out.outputs.artifact_name }}
+      site_dir: ${{ steps.out.outputs.site_dir }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Build English
+        uses: retypeapp/action-build@latest
+        with:
+          override: '{"url":"${{ inputs.url }}"}'
+        env:
+          RETYPE_KEY: ${{ secrets.retype_license }}
+
+      - name: Set outputs
+        id: out
+        shell: bash
+        run: |
+          echo "artifact_name=retype-site" >> "$GITHUB_OUTPUT"
+          echo "site_dir=${RETYPE_OUTPUT_PATH:-.retype}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.out.outputs.artifact_name }}
+          path: ${{ steps.out.outputs.site_dir }}
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
## 📖 Description
This pull request refactors the GitHub Actions workflows for building and publishing the handbook. The main improvement is the introduction of a reusable workflow (`retype-build.yml`) to centralize and standardize the build process, reducing duplication and improving maintainability. Both the PR preview and production publish workflows now use this shared build step, and deployment steps have been simplified and clarified.

**Workflow refactoring and reuse:**

* Added a new reusable workflow `retype-build.yml` that builds the Retype site, sets outputs for the artifact name and site directory, and uploads the built site as an artifact. This workflow is now called by both preview and publish workflows, ensuring consistent build steps and easier future maintenance.

**PR preview workflow improvements (`pr-preview-publish.yml`):**

* Refactored the workflow to use the shared `retype-build.yml` for building the site, and split the process into separate `build` and `deploy` jobs. Deployment now downloads the built artifact and uploads it to S3, followed by CloudFront cache invalidation and PR comment posting.
* Improved the PR comment step to clarify that the preview URL is posted as a comment on the pull request.

**Production publish workflow improvements (`publish.yml`):**

* Refactored the workflow to use the shared `retype-build.yml` for building the site, and split the process into separate `build` and `deploy` jobs. Deployment downloads the built artifact and publishes it to GitHub Pages, with improved branch update handling.

These changes make the workflows more modular, easier to maintain, and ensure a consistent build and deployment process for both preview and production documentation.